### PR TITLE
[BUG-95158] Improve control file

### DIFF
--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -3,8 +3,7 @@ Section: database
 Priority: optional
 Maintainer: Oracle MySQL Product Engineering Team <mysql-build@oss.oracle.com>
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 8.9.4), cmake (>= 2.8.5),
- @DEB_BUILD_DEPS@
+Build-Depends: debhelper (>= 8.9.4), cmake (>= 2.8.5), @DEB_BUILD_DEPS@
 Homepage: http://dev.mysql.com/downloads/shell
 Vcs-Git: https://github.com/mysql/mysql-shell.git
 Vcs-Browser: https://github.com/mysql/mysql-shell
@@ -13,8 +12,7 @@ Package: mysql-shell@PRODUCT_SUFFIX@
 Section: database
 Architecture: any
 Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends},
- @DEB_DEPS@
+Depends: ${shlibs:Depends}, ${misc:Depends}, @DEB_DEPS@
 Conflicts: mysql-shell@CONFLICTING_PRODUCT_SUFFIX@
 Replaces: mysql-shell@CONFLICTING_PRODUCT_SUFFIX@
 Description: MySQL Shell (part of MySQL Server) 8.0


### PR DESCRIPTION
In case if DEB_DEPS and/or DEB_BUILD_DEPS are empty there will be an empty lines in control file.
This empty lines will generate an issue during deb build ` syntax error in debian/control at line 21: block lacks the 'Package' field`
