### PR TITLE
Add support for VERIFY_CA and VERIFY_IDENTITY SslMode's

### DIFF
--- a/modules/adminapi/common/common.cc
+++ b/modules/adminapi/common/common.cc
@@ -300,7 +300,9 @@ std::string resolve_instance_ssl_mode(
   gr_ssl_mode = *pinstance.get_sysvar_string("group_replication_ssl_mode");
 
   // The cluster REQUIRES SSL
-  if (!shcore::str_casecmp(gr_ssl_mode.c_str(), "REQUIRED")) {
+  if ((!shcore::str_casecmp(gr_ssl_mode.c_str(), "REQUIRED")) ||
+      (!shcore::str_casecmp(gr_ssl_mode.c_str(), "VERIFY_CA")) ||
+      (!shcore::str_casecmp(gr_ssl_mode.c_str(), "VERIFY_IDENTITY"))) {
     // memberSslMode is DISABLED
     if (!shcore::str_casecmp(member_ssl_mode.c_str(), "DISABLED"))
       throw shcore::Exception::runtime_error(
@@ -327,7 +329,13 @@ std::string resolve_instance_ssl_mode(
     }
 
     // memberSslMode is either AUTO or REQUIRED
-    ret_val = dba::kMemberSSLModeRequired;
+    if (!shcore::str_casecmp(gr_ssl_mode.c_str(), "REQUIRED")) {
+      ret_val = dba::kMemberSSLModeRequired;
+    } else if (!shcore::str_casecmp(gr_ssl_mode.c_str(), "VERIFY_CA")) {
+      ret_val = dba::kMemberSSLModeVerifyCA;
+    } else if (!shcore::str_casecmp(gr_ssl_mode.c_str(), "VERIFY_IDENTITY")) {
+      ret_val = dba::kMemberSSLModeVerifyIdentity;
+    }
 
     // The cluster has SSL DISABLED
   } else if (!shcore::str_casecmp(gr_ssl_mode.c_str(), "DISABLED")) {

--- a/modules/adminapi/common/common.h
+++ b/modules/adminapi/common/common.h
@@ -221,6 +221,8 @@ std::string get_mysqlprovision_error_string(
 extern const char *kMemberSSLModeAuto;
 extern const char *kMemberSSLModeRequired;
 extern const char *kMemberSSLModeDisabled;
+extern const char *kMemberSSLModeVerifyCA;
+extern const char *kMemberSSLModeVerifyIdentity;
 
 /**
  * Check if a setting is supported on the target instance

--- a/modules/adminapi/common/group_replication_options.cc
+++ b/modules/adminapi/common/group_replication_options.cc
@@ -52,8 +52,11 @@ void validate_group_name_option(std::string group_name) {
 const char *kMemberSSLModeAuto = "AUTO";
 const char *kMemberSSLModeRequired = "REQUIRED";
 const char *kMemberSSLModeDisabled = "DISABLED";
+const char *kMemberSSLModeVerifyCA = "VERIFY_CA";
+const char *kMemberSSLModeVerifyIdentity = "VERIFY_IDENTITY";
 const std::set<std::string> kMemberSSLModeValues = {
-    kMemberSSLModeAuto, kMemberSSLModeDisabled, kMemberSSLModeRequired};
+    kMemberSSLModeAuto, kMemberSSLModeDisabled, kMemberSSLModeRequired,
+    kMemberSSLModeVerifyCA, kMemberSSLModeVerifyIdentity};
 
 void validate_ssl_instance_options(std::string ssl_mode) {
   // Validate use of SSL options for the cluster instance and issue an

--- a/modules/adminapi/common/provision.cc
+++ b/modules/adminapi/common/provision.cc
@@ -75,6 +75,17 @@ void set_gr_options(const mysqlshdk::mysql::IInstance &instance,
                   mysqlshdk::utils::nullable<bool>(true));
       config->set("group_replication_ssl_mode",
                   mysqlshdk::utils::nullable<std::string>("REQUIRED"));
+    } else if (*gr_opts.ssl_mode == mysqlsh::dba::kMemberSSLModeVerifyCA) {
+      config->set("group_replication_recovery_use_ssl",
+                  mysqlshdk::utils::nullable<bool>(true));
+      config->set("group_replication_ssl_mode",
+                  mysqlshdk::utils::nullable<std::string>("VERIFY_CA"));
+    } else if (*gr_opts.ssl_mode ==
+               mysqlsh::dba::kMemberSSLModeVerifyIdentity) {
+      config->set("group_replication_recovery_use_ssl",
+                  mysqlshdk::utils::nullable<bool>(true));
+      config->set("group_replication_ssl_mode",
+                  mysqlshdk::utils::nullable<std::string>("VERIFY_IDENTITY"));
     } else if (*gr_opts.ssl_mode == mysqlsh::dba::kMemberSSLModeDisabled) {
       if (instance.get_version() >= mysqlshdk::utils::Version(8, 0, 5)) {
         // This option is required to connect using the new


### PR DESCRIPTION
MySQL Server does support a `group_replication_ssl_mode` of `DISABLED`, `REQUIRED`, `VERIFY_CA` or `VERIFY_IDENTITY`.

But MySQL Shell only supports `DISABLED` and `REQUIRED`, which this commit fixes.

* https://bugs.mysql.com/bug.php?id=101892
* https://dev.mysql.com/doc/refman/8.0/en/group-replication-options.html#sysvar_group_replication_ssl_mode

This code hasn't been tested yet