### PR TITLE
Fix cmake version needed for build

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,7 +5,7 @@ Dependencies
 ============
 
 Mandatory
-- cmake 2.8.12 (note: if you're using a very recent version of cmake and it
+- cmake 3.5.1 (note: if you're using a very recent version of cmake and it
   doesn't work, try downgrading)
 - gcc 5/VisualStudio 2015/clang 8
 - MySQL client libraries built from sources


### PR DESCRIPTION
According to CMakeLIsts.txt we  need newer cmake version then it is set in documentation
I have tried on different platforms (starting from oracle linux 6)
and got the same message:
```

CMake Error at CMakeLists.txt:107 (CMAKE_MINIMUM_REQUIRED):
  CMake 3.5.1 or higher is required.  You are running version 2.8.12.2
```