### PR TITLE
Add libssh to requirements

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -11,6 +11,7 @@ Mandatory
 - MySQL client libraries built from sources
   (libmysqlclient, libmysqlxclient)
 - zip (gnuwin32 in windows)
+- libssh 0.9.2
 - python 3.7+
 
 Optional


### PR DESCRIPTION
According to CMakeLists.txt we need to install libssh 0.9.2

`find_package(libssh 0.9.2 REQUIRED)`