### PR TITLE
Fix requested python version

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -11,7 +11,7 @@ Mandatory
 - MySQL client libraries built from sources
   (libmysqlclient, libmysqlxclient)
 - zip (gnuwin32 in windows)
-- python 3.7+
+- python 3.8+
 
 Optional
 - gtest and gmock 1.8 (can be automatically downloaded)


### PR DESCRIPTION
According to debian control file and according to rpm spec files it is requested to have python at least 3.8
```

if(HAVE_PYTHON)
  list(APPEND EXTRA_CMAKE_OPTS "-DHAVE_PYTHON=1")
  if (BUNDLED_PYTHON_DIR)
    list(APPEND EXTRA_CMAKE_OPTS "-DBUNDLED_PYTHON_DIR=${BUNDLED_PYTHON_DIR}")
  else()
    list(APPEND DEB_BUILD_DEPS "python3-dev (>= 3.8)")
```

```
%if 0%{?rhel} >= 8
BuildRequires:  python38-devel
%else
BuildRequires:  python3-devel >= 3.8
%endif

```