### PR TITLE
Add antlr4 runtime to INSTALL doc

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -13,10 +13,12 @@ Mandatory
 - zip (gnuwin32 in windows)
 - python 3.8+
 - libssh 0.9.2
+- antlr4 runtime 4.10.1 (patch version should not matter)
 
 Optional
 - gtest and gmock 1.8 (can be automatically downloaded)
 - v8 8.5.210.20
+
 
 Building From Source
 ====================


### PR DESCRIPTION
`antlr4 runtime` library is missed in documentation. As it is mandatory and currently this version doesn't exists in any repos it is better to add it into documentation