### PR TITLE
Handle None diff values when collecting diagnostics

### DIFF
--- a/python/plugins/debug/collect_diagnostics.py
+++ b/python/plugins/debug/collect_diagnostics.py
@@ -341,7 +341,10 @@ def dump_diff(f, key_label, instance_labels, diff, header):
     for k, v in diff:
         line = [k.ljust(column_widths[0])]
         for i, value in enumerate(v):
-            line.append(value.ljust(column_widths[1+i]))
+            if value:
+                line.append(value.ljust(column_widths[1+i]))
+            else:
+                print(f"Detected None diff entry, will not append to line")
         f.write((" | ".join(line) + "\n").encode("utf-8"))
 
 


### PR DESCRIPTION
We have seen that the debug utility that collects diagnostics via MySQL shell fails with an `AttributeError` when executed in a member of a broken GR cluster. This error happens when the `dump_diff()` function is invoked with a `diff` object that contains at least one value that equals None.

Fix this by adding a check to ensure that the value of every diff value to be left-justified is not None before appending it to the current line.

Also, print a descriptive message to inform the user that a None diff value was detected and will be skipped from the current line.

See https://bugs.mysql.com/bug.php?id=114707