### PR TITLE
Fix postrm script to properly handle directory removal

### DIFF
--- a/packaging/debian/postrm.in
+++ b/packaging/debian/postrm.in
@@ -24,8 +24,15 @@
 set -e
 
 if [ "$1" = "purge" ]; then
-        rm -rf /usr/lib/mysqlsh 2>/dev/null
-        echo "Deleted /usr/lib/mysqlsh"
+    if [ -d "/usr/lib/mysqlsh" ]; then
+        if rm -rf /usr/lib/mysqlsh; then
+            echo "Successfully deleted /usr/lib/mysqlsh"
+        else
+            echo "Warning: Failed to delete /usr/lib/mysqlsh" >&2
+        fi
+    else
+        echo "Directory /usr/lib/mysqlsh does not exist, nothing to remove"
+    fi
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
- Check if /usr/lib/mysqlsh exists before attempting removal
- Verify rm command success and provide accurate feedback
- Send error messages to stderr with proper warning format
- Inform user when directory doesn't exist instead of silent operation