### PR TITLE
Fix pre-check for allowed ciphers

### DIFF
--- a/modules/util/upgrade_checker/upgrade_check.cc
+++ b/modules/util/upgrade_checker/upgrade_check.cc
@@ -214,14 +214,35 @@ std::vector<Upgrade_issue> Sys_var_allowed_values_check::run(
 
   std::vector<Upgrade_issue> issues;
 
+  const std::unordered_set<std::string> cipher_params = {
+      "ssl_cipher", "admin_ssl_cipher", "tls_ciphersuites",
+      "admin_tls_ciphersuites"};
+
   for (const auto &variable : m_sys_vars) {
     // Tests for the definition to be enabled
 
     const auto *cached_var = cache->get_sysvar(variable.first);
 
     if (cached_var && cached_var->source != "COMPILED") {
-      if (std::find(variable.second.begin(), variable.second.end(),
-                    cached_var->value) == std::end(variable.second)) {
+      std::vector<std::string> configured_values;
+
+      if (cipher_params.count(variable.first)) {
+        // Cipher params are colon-separated lists; validate each cipher
+        configured_values = shcore::str_split(cached_var->value, ":");
+      } else {
+        configured_values = {cached_var->value};
+      }
+
+      bool invalid_value = false;
+      for (const auto &value : configured_values) {
+        if (std::find(variable.second.begin(), variable.second.end(),
+                      value) == variable.second.end()) {
+          invalid_value = true;
+          break;
+        }
+      }
+
+      if (invalid_value) {
         auto allowed = shcore::str_join(variable.second, ", ");
 
         auto description =


### PR DESCRIPTION
The current cipher pre-checks for upgrading to MySQL 8.4 will check the entire
string for parameters like `ssl_cipher` and `tls_ciphersuites` against a list
of individual allowed ciphers.

If the parameters are configured to be a colon-separated list of ciphers, then
this check will always fail.

Update the check such that each cipher in the colon-separated list will be
checked separately and an error will be raised if the list contains a cipher
that is no longer allowed.

For example, when `ssl_cipher` is set to a list of 2 valid ciphers, `ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384`, the pre-check would throw an error:

```
The following system variables are using values that are not allowed.
ssl_cipher - Error: The system variable 'ssl_cipher' is set to 
'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384', 
allowed values include: ECDHE-ECDSA-AES128-GCM-SHA256, 
ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256, 
ECDHE-RSA-AES256-GCM-SHA384, ECDHE-ECDSA-CHACHA20-POLY1305, 
ECDHE-RSA-CHACHA20-POLY1305, ECDHE-ECDSA-AES256-CCM, 
ECDHE-ECDSA-AES128-CCM, DHE-RSA-AES128-GCM-SHA256, 
DHE-RSA-AES256-GCM-SHA384, DHE-RSA-AES256-CCM, 
DHE-RSA-AES128-CCM, DHE-RSA-CHACHA20-POLY1305
```

## Testing

### ssl_cipher

- default value [PASS]
```
mysql> select @@global.ssl_cipher;
+---------------------+
| @@global.ssl_cipher |
+---------------------+
| NULL                |
+---------------------+

{
            "id": "sysvarAllowedValues",
            "title": "Check for allowed values in System Variables.",
            "status": "OK",
            "detectedProblems": [],
            "solutions": []
},
```

- One allowed [PASS]
```
mysql> select @@global.ssl_cipher;
+-------------------------------+
| @@global.ssl_cipher           |
+-------------------------------+
| ECDHE-ECDSA-AES128-GCM-SHA256 |
+-------------------------------+

        {
            "id": "sysvarAllowedValues",
            "title": "Check for allowed values in System Variables.",
            "status": "OK",
            "detectedProblems": [],
            "solutions": []
        },
```

- Multiple allowed [PASS]
```
mysql> select @@global.ssl_cipher;
+-------------------------------------------------------------+
| @@global.ssl_cipher                                         |
+-------------------------------------------------------------+
| ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384 |
+-------------------------------------------------------------+

        {
            "id": "sysvarAllowedValues",
            "title": "Check for allowed values in System Variables.",
            "status": "OK",
            "detectedProblems": [],
            "solutions": []
        },
```

- Single cipher not allowed [FAIL]
```
mysql> select @@global.ssl_cipher;
+---------------------+
| @@global.ssl_cipher |
+---------------------+
| AES128-GCM-SHA256   |
+---------------------+
1 row in set (0.00 sec)

        {
            "id": "sysvarAllowedValues",
            "title": "Check for allowed values in System Variables.",
            "status": "OK",
            "description": "The following system variables are using values that are not allowed.",
            "detectedProblems": [
                {
                    "level": "Error",
                    "dbObject": "ssl_cipher",
                    "description": "Error: The system variable 'ssl_cipher' is set to 'AES128-GCM-SHA256', allowed values include: ECDHE-ECDSA-AES128-GCM-SHA256, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256, ECDHE-RSA-AES256-GCM-SHA384, ECDHE-ECDSA-CHACHA20-POLY1305, ECDHE-RSA-CHACHA20-POLY1305, ECDHE-ECDSA-AES256-CCM, ECDHE-ECDSA-AES128-CCM, DHE-RSA-AES128-GCM-SHA256, DHE-RSA-AES256-GCM-SHA384, DHE-RSA-AES256-CCM, DHE-RSA-AES128-CCM, DHE-RSA-CHACHA20-POLY1305, ",
                    "dbObjectType": "SystemVariable"
                }
            ],
            "solutions": []
        },
```

- Multiple ciphers, one not allowed [FAIL]
```
mysql> select @@global.ssl_cipher;
+-------------------------------------------------------------------------------+
| @@global.ssl_cipher                                                           |
+-------------------------------------------------------------------------------+
| ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:AES128-GCM-SHA256 |
+-------------------------------------------------------------------------------+

       {
            "id": "sysvarAllowedValues",
            "title": "Check for allowed values in System Variables.",
            "status": "OK",
            "description": "The following system variables are using values that are not allowed.",
            "detectedProblems": [
                {
                    "level": "Error",
                    "dbObject": "ssl_cipher",
                    "description": "Error: The system variable 'ssl_cipher' is set to 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:AES128-GCM-SHA256', allowed values include: ECDHE-ECDSA-AES128-GCM-SHA256, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256, ECDHE-RSA-AES256-GCM-SHA384, ECDHE-ECDSA-CHACHA20-POLY1305, ECDHE-RSA-CHACHA20-POLY1305, ECDHE-ECDSA-AES256-CCM, ECDHE-ECDSA-AES128-CCM, DHE-RSA-AES128-GCM-SHA256, DHE-RSA-AES256-GCM-SHA384, DHE-RSA-AES256-CCM, DHE-RSA-AES128-CCM, DHE-RSA-CHACHA20-POLY1305, ",
                    "dbObjectType": "SystemVariable"
                }
            ],
            "solutions": []
        },
```

- Multiple ciphers, multiple not allowed [FAIL]
```
mysql> select @@global.ssl_cipher;
+-------------------------------------------------------------------+
| @@global.ssl_cipher                                               |
+-------------------------------------------------------------------+
| ECDHE-ECDSA-AES128-GCM-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384 |
+-------------------------------------------------------------------+


        {
            "id": "sysvarAllowedValues",
            "title": "Check for allowed values in System Variables.",
            "status": "OK",
            "description": "The following system variables are using values that are not allowed.",
            "detectedProblems": [
                {
                    "level": "Error",
                    "dbObject": "ssl_cipher",
                    "description": "Error: The system variable 'ssl_cipher' is set to 'ECDHE-ECDSA-AES128-GCM-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384', allowed values include: ECDHE-ECDSA-AES128-GCM-SHA256, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256, ECDHE-RSA-AES256-GCM-SHA384, ECDHE-ECDSA-CHACHA20-POLY1305, ECDHE-RSA-CHACHA20-POLY1305, ECDHE-ECDSA-AES256-CCM, ECDHE-ECDSA-AES128-CCM, DHE-RSA-AES128-GCM-SHA256, DHE-RSA-AES256-GCM-SHA384, DHE-RSA-AES256-CCM, DHE-RSA-AES128-CCM, DHE-RSA-CHACHA20-POLY1305, ",
                    "dbObjectType": "SystemVariable"
                }
            ],
            "solutions": []
        },
```


Similar tests passes for tls_ciphersuites.

## Both ssl_cipher and tls_ciphersuites
```
        {
            "id": "sysvarAllowedValues",
            "title": "Check for allowed values in System Variables.",
            "status": "OK",
            "description": "The following system variables are using values that are not allowed.",
            "detectedProblems": [
                {
                    "level": "Error",
                    "dbObject": "ssl_cipher",
                    "description": "Error: The system variable 'ssl_cipher' is set to 'ECDHE-ECDSA-AES128-GCM-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384', allowed values include: ECDHE-ECDSA-AES128-GCM-SHA256, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES128-GCM-SHA256, ECDHE-RSA-AES256-GCM-SHA384, ECDHE-ECDSA-CHACHA20-POLY1305, ECDHE-RSA-CHACHA20-POLY1305, ECDHE-ECDSA-AES256-CCM, ECDHE-ECDSA-AES128-CCM, DHE-RSA-AES128-GCM-SHA256, DHE-RSA-AES256-GCM-SHA384, DHE-RSA-AES256-CCM, DHE-RSA-AES128-CCM, DHE-RSA-CHACHA20-POLY1305, ",
                    "dbObjectType": "SystemVariable"
                },
                {
                    "level": "Error",
                    "dbObject": "tls_ciphersuites",
                    "description": "Error: The system variable 'tls_ciphersuites' is set to 'TLS_AES_128_CCM_8_SHA256,ubvakd', allowed values include: TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256, TLS_AES_128_CCM_SHA256, ",
                    "dbObjectType": "SystemVariable"
                }
            ],
            "solutions": []
        },
```

## Copyright

This contribution is under the OCA signed by Amazon and covering submissions to the MySQL project.