### PR TITLE
fix backslash shielding

### DIFF
--- a/mysqlshdk/libs/mysql/user_privileges.cc
+++ b/mysqlshdk/libs/mysql/user_privileges.cc
@@ -203,9 +203,9 @@ bool User_privileges::check_if_user_exists(
     const mysqlshdk::mysql::IInstance &instance) const {
   // all users have at least one privilege: USAGE
   const auto result = instance.queryf(
-      "SELECT PRIVILEGE_TYPE FROM INFORMATION_SCHEMA.USER_PRIVILEGES WHERE "
-      "GRANTEE=? LIMIT 1",
-      m_account);
+    "SELECT PRIVILEGE_TYPE FROM INFORMATION_SCHEMA.USER_PRIVILEGES WHERE "
+    "GRANTEE=CONCAT(QUOTE(?),'@',QUOTE(?)) LIMIT 1",
+    m_user, m_host);
   return nullptr != result->fetch_one();
 }
 


### PR DESCRIPTION
MySQL Shell upgrade_checker fails on user privilege check due to improper string literal escaping

Summary: A critical issue in MySQL Shell causes malformed SQL when composing queries that include quoted string literals. The problem surfaces in upgrade_checker during user privilege verification, leading to exceptions in newer versions.

Technical details:
Affected area: upgrade_checker → user privilege check (current_user_exists())
Root cause: The old escaping routine always used backslash-based escaping regardless of the NO_BACKSLASH_ESCAPES sql_mode setting. This produced invalid SQL for GRANTEE values containing quotes.

Old behavior (incorrect but appeared to work):
The Shell generated a query like: SELECT PRIVILEGE_TYPE FROM INFORMATION_SCHEMA.USER_PRIVILEGES WHERE GRANTEE='\'admin\'@\'localhost\'' LIMIT 1;
Despite the SQL being syntactically invalid, an error was swallowed at some processing layer.
The query “slipped through” without a surfaced error, so the Shell assumed the user existed and continued.
As a result, current_user_exists() returned a “correct” outcome by accident for this specific query.

New behavior:
The newer version correctly surfaces the SQL error caused by improper escaping, and the Shell throws an exception during the privilege check.
Impact:
upgrade_checker may fail with an exception when checking user privileges, depending on sql_mode and input requiring proper quoting.

Resolution:
Use correct, mode-independent quoting via single-quote escaping provided by QUOTE(), and construct GRANTEE with CONCAT so it works regardless of NO_BACKSLASH_ESCAPES.
This ensures current_user_exists() executes reliably and does not throw.