### PR TITLE
Bug#120043 Fix mysqlshell Upgrade Checker utility's foreign Key References check to include cross database foreign key references

### DIFF
--- a/modules/util/upgrade_checker/upgrade_check_creators.cc
+++ b/modules/util/upgrade_checker/upgrade_check_creators.cc
@@ -1756,7 +1756,7 @@ R"(select
   fk.table_name,
   fk.constraint_name,
   fk.parent_fk_definition as fk_definition,
-  fk.REFERENCED_TABLE_NAME as target_table,
+  fk.target_table,
   '##fkToNonUniqueKey'
 from (select 
       rc.constraint_schema, 
@@ -1764,6 +1764,7 @@ from (select
       CONCAT(rc.table_name, '(', GROUP_CONCAT(kc.column_name order by kc.ORDINAL_POSITION),')') as parent_fk_definition,
       CONCAT(kc.REFERENCED_TABLE_SCHEMA,'.',kc.REFERENCED_TABLE_NAME, '(', GROUP_CONCAT(kc.REFERENCED_COLUMN_NAME order by kc.POSITION_IN_UNIQUE_CONSTRAINT),')') as target_fk_definition,
       rc.REFERENCED_TABLE_NAME,
+      CONCAT(kc.REFERENCED_TABLE_SCHEMA,'.',rc.REFERENCED_TABLE_NAME) as target_table,
       rc.table_name
     from 
       information_schema.REFERENTIAL_CONSTRAINTS rc
@@ -1772,7 +1773,7 @@ from (select
         on 
           rc.constraint_schema = kc.constraint_schema AND
           rc.constraint_name = kc.constraint_name AND
-          rc.constraint_schema = kc.REFERENCED_TABLE_SCHEMA AND
+          rc.UNIQUE_CONSTRAINT_SCHEMA = kc.REFERENCED_TABLE_SCHEMA AND
           rc.REFERENCED_TABLE_NAME = kc.REFERENCED_TABLE_NAME AND
           kc.REFERENCED_TABLE_NAME is not NULL AND
           kc.REFERENCED_COLUMN_NAME is not NULL
@@ -1782,7 +1783,8 @@ from (select
       rc.constraint_schema,
       rc.constraint_name,
       rc.table_name,
-      rc.REFERENCED_TABLE_NAME) fk
+      rc.REFERENCED_TABLE_NAME,
+      kc.referenced_table_schema) fk
   join (SELECT 
       CONCAT(table_schema,'.',table_name,'(',GROUP_CONCAT(column_name order by seq_in_index),')') as fk_definition,
       SUM(non_unique) as non_unique_count
@@ -1800,7 +1802,8 @@ from (select
     fk.constraint_name,
     fk.parent_fk_definition,
     fk.REFERENCED_TABLE_NAME,
-    fk.table_name
+    fk.table_name,
+    fk.target_table
   having
     SUM(idx.non_unique_count = 0) = 0 AND
     <<fk.schema_and_table_filter:constraint_schema:table_name>>


### PR DESCRIPTION
## Description

The foreignKeyReferences check (fkToNonUniqueKey query) incorrectly filters out foreign keys that reference tables in different schemas due to the condition "rc.constraint_schema = kc.REFERENCED_TABLE_SCHEMA" in the JOIN.

Example:
```
MySQL [(none)]> select CONSTRAINT_SCHEMA, CONSTRAINT_NAME, UNIQUE_CONSTRAINT_SCHEMA, TABLE_NAME, REFERENCED_TABLE_NAME from information_schema.REFERENTIAL_CONSTRAINTS;
+-------------------+--------------------+--------------------------+-------------+-----------------------+
| CONSTRAINT_SCHEMA | CONSTRAINT_NAME    | UNIQUE_CONSTRAINT_SCHEMA | TABLE_NAME  | REFERENCED_TABLE_NAME |
+-------------------+--------------------+--------------------------+-------------+-----------------------+
| collection        | collect_101_ibfk_1 | sample                   | collect_101 | sample_101            |
| collection        | collect_102_ibfk_1 | collection               | collect_102 | collect_101           |
+-------------------+--------------------+--------------------------+-------------+-----------------------+
2 rows in set (0.001 sec)
```
When executing rechecks using mysqlsh with util check-for-server-upgrade, it executes "foreignKeyReferences" check which Checks for foreign keys not referencing a full unique index. This check only identifies foreign keys referenced to with in same schema and ignore foreign keys referencing to different schema.
```
[root@testbox data]# mysqlsh -- util check-for-server-upgrade --user=root --host=localhost --password=**** --socket=/tmp/mysql_sandbox8042.sock --target-version=8.4.8
The MySQL server at /tmp%2Fmysql_sandbox8042.sock, version 8.0.42 - MySQL
Community Server - GPL, will now be checked for compatibility issues for
upgrade to MySQL 8.4.8.
.
.
4) Checks for foreign keys not referencing a full unique index
(foreignKeyReferences)
   Foreign keys to partial indexes may be forbidden as of 8.4.0, this check
   identifies such cases to warn the user.

   collection.collect_102_ibfk_1 - invalid foreign key defined as
      'collect_102(k)' references a non unique key at table 'collect_101'.
.
.
.
[root@testbox data]# 
```

This patch:
 1. Replaces rc.constraint_schema with rc.UNIQUE_CONSTRAINT_SCHEMA in the JOIN condition to correctly handle cross-database FK references
 2. Adds explicit target_table column using CONCAT(schema.table) in inner subquery, consistent with fkToPartialKey approach
 3. Adds kc.referenced_table_schema to inner GROUP BY clause and fk.target_table to outer GROUP BY clause
 4. Enhances target_table output to show schema.table_name format for fkToNonUniqueKey

## Release Notes
The the Upgrade Checker utility's foreign Key References check (`fkToNonUniqueKey`) updated to included foreign keys references across different databases.

## How can this PR be tested?

* Create schema as follows (on 8.0.42) and then execute mysqlsh upgrade prechecks. 

```
CREATE DATABASE IF NOT EXISTS sample;
CREATE DATABASE IF NOT EXISTS collection;

CREATE TABLE IF NOT EXISTS `sample`.`sample_101` (
  `id` int NOT NULL AUTO_INCREMENT,
  `k` int NOT NULL DEFAULT '0',
  `c` char(120) NOT NULL DEFAULT '',
  `pad` char(60) NOT NULL DEFAULT '',
  PRIMARY KEY (`id`),
  KEY `k` (`k`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

CREATE TABLE IF NOT EXISTS `collection`.`collect_101` (
  `id` int NOT NULL AUTO_INCREMENT,
  `k` int NOT NULL DEFAULT '0',
  `c` char(120) NOT NULL DEFAULT '',
  `pad` char(60) NOT NULL DEFAULT '',
  `blob_column` blob,
  PRIMARY KEY (`id`),
  KEY `k` (`k`),
  CONSTRAINT `collect_101_ibfk_1` FOREIGN KEY (`k`) REFERENCES `sample`.`sample_101` (`k`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

CREATE TABLE IF NOT EXISTS `collection`.`collect_102` (
  `id` int NOT NULL,
  `k` int NOT NULL DEFAULT '0',
  `c` char(120) NOT NULL DEFAULT '',
  `pad` char(60) NOT NULL DEFAULT '',
  `blob_column` blob,
  KEY `k` (`k`),
  CONSTRAINT `collect_102_ibfk_1` FOREIGN KEY (`k`) REFERENCES `collect_101` (`k`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
```

* Run mysql shell to upgrade prechecks with target version as 8.4.8

```
mysqlsh -- util check-for-server-upgrade --user=root --host=localhost --password=***** --socket=/tmp/mysql_sandbox8042.sock --target-version=8.4.8
```

NOTE: This can be tested with any versions less than mysql shell version as mysqlshell utility is backward compatible.