### PR TITLE
Fix upgrade sysvars pre-check for colon-delimited cipher lists

### DIFF
--- a/modules/util/upgrade_checker/sysvar_check.cc
+++ b/modules/util/upgrade_checker/sysvar_check.cc
@@ -378,6 +378,8 @@ constexpr const char *k_default = "default";
 constexpr const char *k_allowed = "allowed";
 constexpr const char *k_forbidden = "forbidden";
 constexpr const char *k_vartype = "vartype";
+constexpr const char *k_separator = "separator";
+constexpr const char *k_default_set_separator = " ,";
 
 std::vector<std::string> parse_string_list(const rapidjson::Value &source) {
   std::vector<std::string> result;
@@ -509,6 +511,10 @@ void parse_sysvar(const rapidjson::Value &source, Sysvar_definition *sysvar) {
 
   if (source.HasMember("replacement")) {
     sysvar->replacement = get_string(source["replacement"]);
+  }
+
+  if (source.HasMember(k_separator)) {
+    sysvar->separator = get_string(source[k_separator]);
   }
 
   // Parses the initial values
@@ -680,6 +686,7 @@ std::optional<Sysvar_version_check> Sysvar_definition::get_check(
     }
 
     cnf.vartype = vartype;
+    cnf.separator = separator;
 
     return cnf;
   }
@@ -755,7 +762,7 @@ std::vector<std::string_view> Sysvar_check::get_invalid_allowed_values(
             }
             return true;
           },
-          " ,");
+          sysvar_check.separator.value_or(k_default_set_separator));
     } else if (!cont_contains(sysvar_check.allowed_values, sysvar->value)) {
       invalid_values.push_back(sysvar->value);
     }
@@ -780,7 +787,7 @@ std::vector<std::string_view> Sysvar_check::get_invalid_forbidden_values(
             }
             return true;
           },
-          " ,");
+          sysvar_check.separator.value_or(k_default_set_separator));
     } else if (cont_contains(sysvar_check.forbidden_values, sysvar->value)) {
       invalid_values.push_back(sysvar->value);
     }

--- a/modules/util/upgrade_checker/sysvar_check.h
+++ b/modules/util/upgrade_checker/sysvar_check.h
@@ -106,6 +106,7 @@ struct Sysvar_definition {
   Sysvar_configuration initials;
   std::map<Version, Sysvar_configuration> changes;
   std::optional<std::string> replacement;
+  std::optional<std::string> separator;
 
   void set_default(std::string value,
                    const std::optional<Version> &version = {}, size_t bits = 0,
@@ -136,6 +137,7 @@ struct Sysvar_version_check {
   std::optional<Version> removal_version;
   std::optional<Version> deprecation_version;
   std::optional<Variable_type> vartype;
+  std::optional<std::string> separator;
 };
 
 class Sysvar_registry {

--- a/res/upgrade_checker/sysvars.json
+++ b/res/upgrade_checker/sysvars.json
@@ -235,6 +235,7 @@
   },
   {
     "name": "admin_ssl_cipher",
+    "separator": " ,:",
     "version": "8.0.21",
     "initial": {
       "all": {
@@ -273,6 +274,7 @@
   },
   {
     "name": "admin_tls_ciphersuites",
+    "separator": " ,:",
     "version": "8.0.21",
     "initial": {
       "all": {
@@ -5400,6 +5402,7 @@
   },
   {
     "name": "ssl_cipher",
+    "separator": " ,:",
     "version": "5.0.23",
     "initial": {
       "all": {
@@ -5803,6 +5806,7 @@
   },
   {
     "name": "tls_ciphersuites",
+    "separator": " ,:",
     "version": "8.0.16",
     "initial": {
       "all": {

--- a/scripts/upgrade_checker/update_sysvar_configuration.py
+++ b/scripts/upgrade_checker/update_sysvar_configuration.py
@@ -41,6 +41,17 @@ FORCE_TYPES={
     "admin_tls_ciphersuites": "set",
 }
 
+# Set-typed variables whose elements are separated by characters other than the
+# default space/comma. The upgrade checker splits the value on ANY of these
+# characters before validating each element against the allowed list. Cipher
+# lists are colon-separated but also accept comma/space, so they carry " ,:".
+FORCE_SEPARATORS={
+    "ssl_cipher": " ,:",
+    "admin_ssl_cipher": " ,:",
+    "tls_ciphersuites": " ,:",
+    "admin_tls_ciphersuites": " ,:",
+}
+
 class Sysvar_definition_error(Exception):
     def __init__(self, *args: object) -> None:
         super().__init__(*args)
@@ -767,6 +778,10 @@ class Xml_sysvar(object):
     def shell_config(self):
         config = {}
         config["name"] = self.name
+
+        separator = FORCE_SEPARATORS.get(self.name)
+        if separator is not None:
+            config["separator"] = separator
 
         if self.introduced:
             config["version"] = self.introduced

--- a/unittest/modules/util/upgrade_checker/sysvar_upgrade_check_t.cc
+++ b/unittest/modules/util/upgrade_checker/sysvar_upgrade_check_t.cc
@@ -32,6 +32,7 @@
 #include "unittest/modules/util/upgrade_checker/test_utils.h"
 #include "unittest/test_utils.h"
 #include "unittest/test_utils/mocks/mysqlshdk/libs/db/mock_session.h"
+#include "unittest/test_utils/mocks/mysqlshdk/libs/db/mock_session_pool.h"
 
 namespace mysqlsh {
 namespace upgrade_checker {
@@ -1077,6 +1078,102 @@ TEST(Upgrade_checker_sysvar_registry, load_configuration) {
 
     EXPECT_STREQ("0", check->forbidden_values[0].c_str());
   }
+
+  // Verifies the cipher list variables carry a separator that includes the
+  // colon. These variables hold colon-separated cipher lists, so the Set-value
+  // splitter must split on ':' (in addition to space/comma) before validating
+  // each cipher against the allowed list. See sysvar_check.cc split helpers.
+  {
+    for (const auto &name :
+         {"ssl_cipher", "admin_ssl_cipher", "tls_ciphersuites",
+          "admin_tls_ciphersuites"}) {
+      auto sysvar = reg.get_sysvar(name);
+      ASSERT_TRUE(sysvar.separator.has_value())
+          << "missing separator for " << name;
+      EXPECT_STREQ(" ,:", sysvar.separator.value().c_str())
+          << "unexpected separator for " << name;
+
+      auto ui = upgrade_info(Version(8, 4, 0), Version(9, 7, 0));
+      auto check = sysvar.get_check(ui);
+      ASSERT_TRUE(check.has_value()) << "no check produced for " << name;
+      ASSERT_TRUE(check->separator.has_value())
+          << "separator not carried into check for " << name;
+      EXPECT_STREQ(" ,:", check->separator.value().c_str());
+    }
+  }
+}
+
+namespace {
+// Runs the sysvar upgrade check against a cache pre-populated with the given
+// cipher values and returns the resulting issues. The cache is filled via
+// override_sysvar before run(), so Checker_cache::cache_sysvars() short-circuits
+// (it early-returns on a non-empty cache) and the mock session is never queried.
+std::vector<Upgrade_issue> run_cipher_check(
+    const std::vector<std::pair<std::string, std::string>> &cipher_values) {
+  auto server_info = upgrade_info(Version(8, 4, 0), Version(9, 7, 0));
+
+  Sysvar_check check(server_info);
+
+  auto msession = std::make_shared<testing::Mock_session>();
+  auto mock_pool = std::make_shared<testing::Mock_session_pool>();
+  mock_pool->setup_repeated_session(msession);
+
+  Upgrade_check_options options;
+  Checker_cache cache(options.filters);
+  for (const auto &[name, value] : cipher_values) {
+    override_sysvar(&cache, name, value);
+  }
+
+  return check.run(
+      {msession, server_info,
+       std::dynamic_pointer_cast<mysqlshdk::db::Session_pool>(mock_pool),
+       &cache});
+}
+
+// Counts issues whose schema matches the given sysvar name (issue.schema is set
+// to the variable name by Sysvar_check::get_issue).
+size_t count_issues_for(const std::vector<Upgrade_issue> &issues,
+                        const std::string &name) {
+  size_t count = 0;
+  for (const auto &issue : issues) {
+    if (issue.schema == name) ++count;
+  }
+  return count;
+}
+}  // namespace
+
+// Regression test for the colon-separated cipher list false positive: a
+// ssl_cipher / tls_ciphersuites value that is a colon-separated list of
+// individually-allowed ciphers must NOT be reported as invalid. Before the
+// separator fix the whole colon-joined string was compared against the list of
+// individual ciphers and always failed.
+TEST(Upgrade_checker_Sysvar_check, cipher_colon_list_allowed) {
+  auto issues = run_cipher_check(
+      {{"ssl_cipher",
+        "ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA256"},
+       {"tls_ciphersuites",
+        "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384"}});
+
+  EXPECT_EQ(0, count_issues_for(issues, "ssl_cipher"));
+  EXPECT_EQ(0, count_issues_for(issues, "tls_ciphersuites"));
+}
+
+// A colon-separated list that contains a cipher which is NOT in the allowed
+// list must still be flagged
+TEST(Upgrade_checker_Sysvar_check, cipher_colon_list_with_invalid) {
+  // RC4-MD5 is a valid OpenSSL cipher name but is not in the 8.4 allowed list.
+  auto issues = run_cipher_check(
+      {{"ssl_cipher", "ECDHE-RSA-AES128-GCM-SHA256:RC4-MD5"}});
+
+  EXPECT_EQ(1, count_issues_for(issues, "ssl_cipher"));
+}
+
+// A single allowed cipher (no separator present in the value) must pass
+TEST(Upgrade_checker_Sysvar_check, cipher_single_value_allowed) {
+  auto issues =
+      run_cipher_check({{"ssl_cipher", "ECDHE-RSA-AES128-GCM-SHA256"}});
+
+  EXPECT_EQ(0, count_issues_for(issues, "ssl_cipher"));
 }
 
 }  // namespace upgrade_checker


### PR DESCRIPTION
## Description

The upgrade checker's system-variable check validates `Set`-typed variables by
splitting the configured value into individual elements and checking each
element against the variable's allowed-values list
(`Sysvar_check::get_invalid_allowed_values` / `get_invalid_forbidden_values` in
`modules/util/upgrade_checker/sysvar_check.cc`). The split was hard-coded to use
space and comma (`" ,"`) as the only element separators.

The four cipher-list variables: `ssl_cipher`, `admin_ssl_cipher`,
`tls_ciphersuites`, `admin_tls_ciphersuites` are colon-delimited.
They are marked `vartype: set` in `sysvars.json`, so they went through the Set splitter, but colon was never a
recognized separator. 
A value like `ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA256` was therefore compared as
one opaque token against the list of individual ciphers, never matched, and the
whole value was reported as invalid resulting in a false positive even when every cipher in
the list is allowed.

Failing precheck example:
```
The MySQL server at repro-mysql84:3306, version 8.4.6 - MySQL Community Server
- GPL, will now be checked for compatibility issues for upgrade to MySQL 9.7.0.

1) System variable check for deprecation, removal, changes in defaults values
or invalid values. (sysVars)
   Following system variables that were detected as being used ware changed,
   deprecated or removed. Please update  your system accordingly before the
   upgrade.

   Error: The following system variables that were detected as being used are
   using values that are  invalid in the target version.
   - ssl_cipher: variable value includes
   'ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA256', allowed values
   include: ECDHE-ECDSA-AES128-GCM-SHA256, ECDHE-ECDSA-AES256-GCM-SHA384,
   ECDHE-RSA-AES128-GCM-SHA256, ECDHE-RSA-AES256-GCM-SHA384,
   ECDHE-ECDSA-CHACHA20-POLY1305, ECDHE-RSA-CHACHA20-POLY1305,
   ECDHE-ECDSA-AES256-CCM, ECDHE-ECDSA-AES128-CCM, DHE-RSA-AES128-GCM-SHA256,
   DHE-RSA-AES256-GCM-SHA384, DHE-RSA-AES256-CCM, DHE-RSA-AES128-CCM,
   DHE-RSA-CHACHA20-POLY1305, .
   - tls_ciphersuites: variable value includes
   'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384', allowed values include:
   TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384,
   TLS_CHACHA20_POLY1305_SHA256, TLS_AES_128_CCM_SHA256,
```

A similar fix for the `8.4` branch was published in https://github.com/mysql/mysql-shell/pull/24 but was ultimately not accepted as MySQL Shell 8.4 only receives critical updates. A partial fix in MySQL Shell 9.x was made to allow for comma delimited cipher lists but did not properly allow for colon delimited cipher lists.

### Fix

We introduce a per-variable element separator property that can configure the allowed delimiters for a set typed variable.

Only the four cipher variables carry the colon-inclusive separator (` ,:`). The other
`Set`-typed variables (`optimizer_switch`, `sql-mode`,
`slave_type_conversions`, `slave_rows_search_algorithms`) are comma-separated and
keep the default, so their behavior is untouched.

## Release Notes

Fixed an upgrade-checker issue where a colon-separated list of TLS/SSL ciphers in
`ssl_cipher`, `admin_ssl_cipher`, `tls_ciphersuites`, or `admin_tls_ciphersuites`
was incorrectly reported as an invalid value during
`util.checkForServerUpgrade()`, even when every cipher in the list was allowed in
the target version. Each cipher in the list is now validated individually.

### Testing

New/updated cases in
`unittest/modules/util/upgrade_checker/sysvar_upgrade_check_t.cc`:

- `Upgrade_checker_Sysvar_check.cipher_colon_list_allowed` — a colon-separated
  list of individually-allowed ciphers produces **no** issue.
- `Upgrade_checker_Sysvar_check.cipher_colon_list_with_invalid` — a colon list
  containing a disallowed cipher is still flagged.
- `Upgrade_checker_Sysvar_check.cipher_single_value_allowed` — the single-value
  path still passes.
- `Upgrade_checker_sysvar_registry.load_configuration` — extended to assert the
  four cipher variables load with `separator == " ,:"`.

## Copyright

This contribution is under the OCA signed by Amazon and covering submissions to
the MySQL project.