### PR TITLE
Bug#120948 Add removedLegacyHashingFunctions upgrade check for MySQL 9.7

### DIFF
--- a/modules/util/upgrade_checker/common.cc
+++ b/modules/util/upgrade_checker/common.cc
@@ -88,6 +88,7 @@ const std::set<std::string_view> all = {
     k_partitions_with_prefix_keys,
     k_foreign_key_references,
     k_spatial_index,
+    k_removed_legacy_hashing_functions_check,
 };
 
 }  // namespace ids

--- a/modules/util/upgrade_checker/common.h
+++ b/modules/util/upgrade_checker/common.h
@@ -113,6 +113,8 @@ inline constexpr std::string_view k_partitions_with_prefix_keys =
 inline constexpr std::string_view k_foreign_key_references =
     "foreignKeyReferences";
 inline constexpr std::string_view k_spatial_index = "spatialIndex";
+inline constexpr std::string_view k_removed_legacy_hashing_functions_check =
+    "removedLegacyHashingFunctions";
 
 // NOTE: Every added id should be included here
 extern const std::set<std::string_view> all;

--- a/modules/util/upgrade_checker/upgrade_check_creators.cc
+++ b/modules/util/upgrade_checker/upgrade_check_creators.cc
@@ -944,6 +944,127 @@ std::unique_ptr<Sql_upgrade_check> get_removed_functions_check() {
   return std::make_unique<Removed_functions_check>();
 }
 
+class Removed_legacy_hashing_functions_check : public Sql_upgrade_check {
+ private:
+  static const std::unordered_map<std::string, const char *> functions;
+
+ public:
+  Removed_legacy_hashing_functions_check()
+      : Sql_upgrade_check(
+            ids::k_removed_legacy_hashing_functions_check, Category::SCHEMA,
+            {{"select table_schema, table_name, '', 'VIEW', "
+              "UPPER(view_definition) from information_schema.views where "
+              "<<schema_and_table_filter>>",
+              Upgrade_issue::Object_type::VIEW},
+             {"select routine_schema, routine_name, '', routine_type, "
+              "UPPER(routine_definition) from information_schema.routines where"
+              " <<schema_and_routine_filter>> and routine_definition is not "
+              "null",
+              Upgrade_issue::Object_type::ROUTINE},
+             {"select TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, "
+              "EXTRA, UPPER(GENERATION_EXPRESSION) from "
+              "information_schema.columns where "
+              "extra in ('VIRTUAL GENERATED', 'STORED GENERATED') and "
+              "<<schema_and_table_filter>>",
+              Upgrade_issue::Object_type::COLUMN},
+             {"select TRIGGER_SCHEMA, EVENT_OBJECT_TABLE, TRIGGER_NAME, "
+              "'TRIGGER', UPPER(ACTION_STATEMENT) from "
+              "information_schema.triggers where <<schema_and_trigger_filter>>",
+              Upgrade_issue::Object_type::TRIGGER},
+             {"select event_schema, event_name, '', 'EVENT', "
+              "UPPER(EVENT_DEFINITION) from information_schema.events where "
+              "<<schema_and_event_filter>>",
+              Upgrade_issue::Object_type::EVENT},
+             {"select tc.TABLE_SCHEMA, tc.TABLE_NAME, cc.CONSTRAINT_NAME, "
+              "'CHECK CONSTRAINT', UPPER(cc.CHECK_CLAUSE) from "
+              "information_schema.CHECK_CONSTRAINTS cc "
+              "join information_schema.TABLE_CONSTRAINTS tc "
+              "on cc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA "
+              "and cc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME "
+              "where tc.CONSTRAINT_TYPE = 'CHECK' and "
+              "<<tc.schema_and_table_filter>>",
+              Upgrade_issue::Object_type::TABLE},
+             {"select TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, "
+              "'COLUMN DEFAULT', UPPER(COLUMN_DEFAULT) from "
+              "information_schema.columns where "
+              "COLUMN_DEFAULT is not null and "
+              "EXTRA not in ('VIRTUAL GENERATED', 'STORED GENERATED') "
+              "and <<schema_and_table_filter>>",
+              Upgrade_issue::Object_type::COLUMN},
+             {"select TABLE_SCHEMA, TABLE_NAME, INDEX_NAME, "
+              "'FUNCTIONAL INDEX', UPPER(EXPRESSION) from "
+              "information_schema.statistics where EXPRESSION is not null and "
+              "<<schema_and_table_filter>>",
+              Upgrade_issue::Object_type::INDEX}},
+            Upgrade_issue::WARNING) {}
+
+  bool is_multi_lvl_check() const override { return true; }
+
+ protected:
+  Upgrade_issue parse_row(const std::vector<std::string> &,
+                          const mysqlshdk::db::IRow *row,
+                          Upgrade_issue::Object_type object_type) override {
+    auto res = create_issue();
+    std::vector<std::pair<std::string, const char *>> flagged_functions;
+    std::string definition = row->get_as_string(4);
+    mysqlshdk::utils::SQL_iterator it(definition);
+    std::string func;
+    while (!(func = it.next_sql_function()).empty()) {
+      auto i = functions.find(func);
+      if (i != functions.end()) flagged_functions.emplace_back(*i);
+    }
+
+    if (flagged_functions.empty()) return res;
+
+    std::string object_type_str = row->get_as_string(3);
+
+    // Objects that block or brick the upgrade cannot be resolved post-upgrade:
+    // - Generated columns: loadable functions disallowed, table bricked
+    // - Functional indexes: server blocks upgrade
+    // - CHECK constraints: server blocks upgrade
+    // - DEFAULT expressions: server blocks upgrade
+    // Recoverable objects (upgrade succeeds, install component post-upgrade):
+    // - Views, routines, triggers, events
+    bool is_recoverable = (object_type_str == "VIEW" ||
+                           object_type_str == "PROCEDURE" ||
+                           object_type_str == "FUNCTION" ||
+                           object_type_str == "TRIGGER" ||
+                           object_type_str == "EVENT");
+
+    std::stringstream ss;
+    ss << object_type_str << " uses removed function";
+    if (flagged_functions.size() > 1) ss << "s";
+    for (std::size_t i = 0; i < flagged_functions.size(); ++i) {
+      ss << (i > 0 ? ", " : " ") << flagged_functions[i].first;
+      if (flagged_functions[i].second != nullptr)
+        ss << " (consider using " << flagged_functions[i].second << " instead)";
+    }
+
+    res.schema = row->get_as_string(0);
+    res.table = row->get_as_string(1);
+    res.column = row->get_as_string(2);
+    res.description = ss.str();
+    res.object_type = object_type;
+
+    // WARNING for views/routines/triggers/events (recoverable via component)
+    // ERROR for everything else (blocks upgrade or bricks the table)
+    res.level = is_recoverable ? Upgrade_issue::WARNING : Upgrade_issue::ERROR;
+
+    return res;
+  }
+};
+
+const std::unordered_map<std::string, const char *>
+    Removed_legacy_hashing_functions_check::functions = {
+        {"MD5", "SHA2 or an alternative approach"},
+        {"SHA1", "SHA2 or an alternative approach"},
+        {"SHA", "SHA2 or an alternative approach"},
+};
+
+std::unique_ptr<Sql_upgrade_check> get_removed_legacy_hashing_functions_check() {
+  return std::make_unique<Removed_legacy_hashing_functions_check>();
+}
+
 class Groupby_asc_syntax_check : public Sql_upgrade_check {
  public:
   Groupby_asc_syntax_check()

--- a/modules/util/upgrade_checker/upgrade_check_creators.h
+++ b/modules/util/upgrade_checker/upgrade_check_creators.h
@@ -97,6 +97,8 @@ std::unique_ptr<Upgrade_check> get_foreign_key_references_check();
 
 std::unique_ptr<Upgrade_check> get_spatial_index_check();
 
+std::unique_ptr<Sql_upgrade_check> get_removed_legacy_hashing_functions_check();
+
 }  // namespace upgrade_checker
 }  // namespace mysqlsh
 

--- a/modules/util/upgrade_checker/upgrade_check_registry.cc
+++ b/modules/util/upgrade_checker/upgrade_check_registry.cc
@@ -299,6 +299,11 @@ bool register_manual_checks() {
         &get_partitions_with_prefix_keys_check, Target::OBJECT_DEFINITIONS,
         "8.4.0");
 
+[[maybe_unused]] bool register_removed_legacy_hashing_functions =
+    Upgrade_check_registry::register_check(
+        std::bind(&get_removed_legacy_hashing_functions_check),
+        Target::OBJECT_DEFINITIONS, "9.6.0");
+
 [[maybe_unused]] bool register_get_spatial_index_check =
     Upgrade_check_registry::register_check(
         std::bind(&get_spatial_index_check), Target::OBJECT_DEFINITIONS,

--- a/res/upgrade_checker/upgrade_checker.msg
+++ b/res/upgrade_checker/upgrade_checker.msg
@@ -692,6 +692,23 @@ Remove foreign keys referring to non unique key/partial columns of key.
 In case of multi level references which involves more than two tables change
 foreign key reference.
 
+* removedLegacyHashingFunctions.title
+Usage of removed legacy hashing functions (MD5, SHA1, SHA)
+
+* removedLegacyHashingFunctions.description
+The following DB objects use MD5(), SHA1(), or SHA() functions that are removed
+as of MySQL 9.6.0. If a generated column within any table uses these functions
+and MySQL server is upgraded to 9.6.0 or later, the table stops working. To
+resolve this, you must dispose of the generated column and either use triggers
+on the table to generate the column value, or rewrite the expression to use an
+alternative such as SHA2(). Functional indexes, CHECK constraints, and DEFAULT
+expressions using these functions will block the upgrade. For views, routines,
+triggers, and events, these can be resolved after upgrade by installing
+component_classic_hashing, or rewritten before upgrading.
+
+* removedLegacyHashingFunctions.docLink
+https://dev.mysql.com/doc/refman/9.7/en/legacy-hashing-component.html
+
 * spatialIndex.title
 Checks for Spatial Indexes
 


### PR DESCRIPTION
### Description
---
The MySQL Shell upgrade checker (`util.checkForServerUpgrade()`) does not detect usage of `MD5()`, `SHA1()`, or `SHA()` functions in database objects when upgrading from 8.4 to 9.6+. These functions were removed from the server binary in MySQL 9.6.0 and moved to `component_classic_hashing`.

The existing `removedFunctions` check is registered at version 8.0.11, so its version condition (`8.0.11 > 8.4.x`) evaluates to false and the check is skipped entirely for 8.4+ source versions. This leaves a gap: if a generated column within any table uses these functions and MySQL server is upgraded to 9.6.0 or later, the table stops working. The server does not re-validate stored generated column expressions during upgrade, and `component_classic_hashing` cannot help since loadable functions are disallowed in generated column expressions (ERROR 3763). The only recovery path is restoring from a pre-upgrade backup.

### How to recreate the issue
---
1. Set up a MySQL 8.4 server.
2. Create a table with a STORED generated column using MD5:
   ```sql
   CREATE TABLE t (id INT PRIMARY KEY, val VARCHAR(255),
     h VARCHAR(32) GENERATED ALWAYS AS (MD5(val)) STORED);
   INSERT INTO t VALUES (1, 'hello', DEFAULT);
   ```
3. Run `util.checkForServerUpgrade()` targeting 9.7.0:
   ```
   mysqlsh root@localhost --util check-for-server-upgrade --target-version=9.7.0
   ```
4. Observe that no error or warning is reported for the generated column.
5. Upgrade to MySQL 9.7.0.
6. Attempt any operation on the table:
   ```sql
   SELECT * FROM t;
   -- ERROR 3763 (HY000): Expression of generated column 'h' contains a disallowed function: md5.
   ```

The table is now permanently inaccessible and SELECT, INSERT, ALTER TABLE DROP COLUMN, SHOW CREATE TABLE, and TRUNCATE all fail with ERROR 3763.

### Fix
---
This patch adds a new `removedLegacyHashingFunctions` upgrade check that scans 8 object types for usage of the removed functions: views, stored routines, triggers, events, generated columns (STORED and VIRTUAL), CHECK constraints, DEFAULT expressions, and functional indexes.

Severity is split based on recoverability:

- **ERROR** for generated columns, functional indexes, CHECK constraints, and DEFAULT expressions as these either permanently brick the table or block the upgrade, and cannot be resolved by installing the component.
- **WARNING** for views, routines, triggers, and events as these can be resolved after upgrade by installing `component_classic_hashing`, or rewritten before upgrading.

The check is registered at version `9.6.0` so it fires for upgrades from 8.4+ to 9.6+

### Testing
---
- Tested against Docker MySQL 8.4.10 with all 10 object types: 5 errors, 5 warnings as expected.
- Verified actual upgrade behavior on MySQL 9.7:
  - Generated columns (STORED/VIRTUAL): ERROR 3763, even with component installed that confirms ERROR severity.
  - Functional indexes, CHECK constraints, DEFAULT expressions: server rejects creation that confirms ERROR severity.
  - Views, routines, triggers, events: work correctly after `INSTALL COMPONENT 'file://component_classic_hashing'` that confirms WARNING severity.

### References
---
- https://dev.mysql.com/doc/refman/9.7/en/legacy-hashing-component.html
- https://blogs.oracle.com/mysql/post/mysql-9-x-moving-away-from-sha1-and-md5
---
This contribution is under the OCA signed by Amazon and covering submissions to the MySQL project.