### PR TITLE
Fix cmake line continuation in non-static RPM builds

### DIFF
--- a/packaging/rpm/mysql-shell.spec.in
+++ b/packaging/rpm/mysql-shell.spec.in
@@ -198,7 +198,7 @@ cmake .. \
     -DMYSQLCLIENT_STATIC_LINKING=ON \
 %else
     -DMYSQLCLIENT_STATIC_LINKING=ON \
-    -DHAVE_JS=OFF
+    -DHAVE_JS=OFF \
 %endif
 %if 0%{?with_protobuf:1}
     -DWITH_PROTOBUF=%{with_protobuf} \


### PR DESCRIPTION
The `%else` branch of `%if 0%{?static}` in `packaging/rpm/mysql-shell.spec.in` ends `-DHAVE_JS=OFF` without a trailing backslash:

```spec
%if 0%{?static}
    -DMYSQLCLIENT_STATIC_LINKING=ON \
%else
    -DMYSQLCLIENT_STATIC_LINKING=ON \
    -DHAVE_JS=OFF          <-- no trailing backslash
%endif
```

This terminates the `cmake` invocation. Everything after it — `-DWITH_PROTOBUF`, `-DMYSQL_SOURCE_DIR`, `-DHAVE_PYTHON=1`, `-DLIBEXECDIR` — is then parsed as a separate shell command and `%build` fails.

Only builds without `--define "static 1"` are affected, which is presumably why it has gone unnoticed.

Present in 8.4.8, 8.4.10, 9.6.0, 9.7.1 and master (line 198 on 8.4.x, 201 on 9.x/master).

**Fix:** add the trailing backslash.

Found while building RPMs from source on Oracle Linux 9.