### PR TITLE
Skip innovation parser when its series is already bundled

### DIFF
--- a/mysqlshdk/libs/yparser/mysql/CMakeLists.txt
+++ b/mysqlshdk/libs/yparser/mysql/CMakeLists.txt
@@ -343,14 +343,26 @@ endif()
 
 # build libraries for all bundled parsers
 set(PARSERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/yacc")
+set(BUNDLED_PARSER_SERIES)
 file(GLOB DIR_CONTENTS LIST_DIRECTORIES true "${PARSERS_DIR}/*")
 foreach(FULL_PATH ${DIR_CONTENTS})
     get_filename_component(VERSION "${FULL_PATH}" NAME)
 
     if(IS_DIRECTORY "${FULL_PATH}" AND VERSION MATCHES "[0-9]+\\.[0-9]+\\.[0-9]+")
         create_parser_plugin(PATH "${FULL_PATH}" VERSION "${VERSION}")
+        GET_MAJOR_MINOR("${VERSION}" BUNDLED_SERIES)
+        list(APPEND BUNDLED_PARSER_SERIES "${BUNDLED_SERIES}")
     endif()
 endforeach()
 
-# parser for the current innovation release
-create_parser_plugin(PATH "${MYSQL_SOURCE_DIR}/sql" VERSION "${MYSQL_VERSION}")
+# parser for the current innovation release, unless a bundled parser already
+# covers that series: plugin and generator target names are keyed on
+# major.minor, so building both would be a target name collision
+GET_MAJOR_MINOR("${MYSQL_VERSION}" MYSQL_VERSION_SERIES)
+list(FIND BUNDLED_PARSER_SERIES "${MYSQL_VERSION_SERIES}" _bundled_index)
+if(NOT _bundled_index EQUAL -1)
+    message(STATUS "Parser for MySQL ${MYSQL_VERSION} is already bundled "
+                   "(series ${MYSQL_VERSION_SERIES}), skipping")
+else()
+    create_parser_plugin(PATH "${MYSQL_SOURCE_DIR}/sql" VERSION "${MYSQL_VERSION}")
+endif()


### PR DESCRIPTION
`create_parser_plugin()` names its targets after the major.minor of the parser version (`mysql_9.7`, `gen_lex_hash_9.7`). A plugin is built for every directory under `yacc/`, and then one more for the server the shell is built against. When that server's series matches a bundled parser, configure fails:

```
CMake Error at mysqlshdk/libs/yparser/mysql/CMakeLists.txt:123 (add_executable):
  add_executable cannot create target "gen_lex_hash_9.7" because another
  target with the same name already exists.
```

master bundles `5.7.44`, `8.0.36`, `8.4.0` and `9.7.0`, so it cannot be built against any 5.7, 8.0, 8.4 or 9.7 server. That includes the 8.4 LTS series, and the `mysql-9.7.0` that `INSTALL.md` instructs the reader to clone:

```
git clone --depth 1 --branch mysql-9.7.0 https://github.com/mysql/mysql-server.git mysql-server
```

(`INSTALL.md` documents the 9.7.0 *shell* tag rather than master, but nothing states that, so following it on master reproduces the failure.)

**Fix:** record the major.minor of each bundled parser and skip the extra plugin when the server's series is already covered, logging that it did so. `list(FIND)` is used rather than `IN_LIST` to avoid depending on CMP0057.

Found while building master against MySQL Server 9.7.0; worked around by building against 9.6.1 instead.