### PR TITLE
Relax warnings-as-errors on the parser plugin link line

### DIFF
--- a/mysqlshdk/libs/yparser/mysql/CMakeLists.txt
+++ b/mysqlshdk/libs/yparser/mysql/CMakeLists.txt
@@ -188,6 +188,13 @@ function(create_parser_plugin)
 
     # create the plugin
     add_library(${PLUGIN_NAME} MODULE ${MYSQL_SOURCES} ${PLUGIN_SOURCES})
+
+    # The generated parser sources are diagnosed again at link time when LTO is
+    # enabled, where the per-source COMPILE_FLAGS above no longer apply, so
+    # relax warnings on the link line as well
+    if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_link_options(${PLUGIN_NAME} PRIVATE "-Wno-error")
+    endif()
     target_compile_definitions(${PLUGIN_NAME} PRIVATE
         "BUILDING_PARSER_PLUGIN"
         "PARSER_VERSION=\"${ARG_VERSION}\""


### PR DESCRIPTION
The generated bison parsers already build with `-Wno-error` because they are generated code the project does not control:

```cmake
set_property(
    SOURCE ${MYSQL_SOURCES} "${GEN_LEX_HASH_OUT}"
    APPEND_STRING
    PROPERTY COMPILE_FLAGS "-Wno-error -Wno-format ..."
)
```

With LTO enabled the compiler diagnoses those same sources again at link time, where per-source `COMPILE_FLAGS` no longer apply, so the global `-Werror` makes the diagnostics fatal.

This is what breaks Debian and Ubuntu builds, which enable `-flto=auto` by default via `dpkg-buildflags`. Each yparser plugin links `sql_yacc.cc` and `sql_hints.yy.cc`, and both define a file-scope `enum yysymbol_kind_t` with different enumerators:

```
sql_yacc.cc:104:6: error: type 'yysymbol_kind_t' violates the C++ One Definition Rule [-Werror=odr]
sql_hints.yy.cc:104:6: note: an enum with different value name is defined in another translation unit
lto1: all warnings being treated as errors
```

The ODR violation itself is real and worth fixing separately — this change only stops it being fatal, by applying to the link line the same relaxation the sources already receive.

Reproduced with `dpkg-buildpackage` on Ubuntu 24.04; worked around downstream by stripping the LTO flags.