### PR TITLE
Do not rewrite RPATH of bundled libexec binaries

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -187,6 +187,9 @@ IF(BUNDLED_MYSQLBINLOG)
       BINARIES "${BUNDLED_MYSQLBINLOG}"
       DESTINATION "${INSTALL_LIBEXECDIR}"
       TARGET api_modules
+      # This binary links only system libraries; rewriting its RPATH is both
+      # unnecessary and, as with libfido2, corrupts it during RPM packaging
+      WRITE_RPATH FALSE
       EXTRA_COPY_COMMANDS ${EXTRA_COPY_COMMANDS}
   )
 ENDIF()

--- a/mysql-secret-store/login-path/CMakeLists.txt
+++ b/mysql-secret-store/login-path/CMakeLists.txt
@@ -53,5 +53,8 @@ IF(BUNDLED_MYSQL_CONFIG_EDITOR)
       BINARIES "${BUNDLED_MYSQL_CONFIG_EDITOR}"
       DESTINATION "${INSTALL_LIBEXECDIR}"
       TARGET mysql-secret-store-login-path
+      # This binary links only system libraries; rewriting its RPATH is both
+      # unnecessary and, as with libfido2, corrupts it during RPM packaging
+      WRITE_RPATH FALSE
   )
 ENDIF()


### PR DESCRIPTION
`mysqlbinlog` and `mysql_config_editor` are bundled into `libexec` and link only system libraries, so they never need an `$ORIGIN`-relative RPATH. Rewriting it anyway leaves them corrupted once installed from an RPM:

```
$ /usr/libexec/mysqlsh/mysqlbinlog --version
/usr/libexec/mysqlsh/mysqlbinlog: no version information available
    (required by /usr/libexec/mysqlsh/mysqlbinlog)

$ /usr/libexec/mysqlsh/mysql_config_editor print --all
Segmentation fault (core dumped)
```

The same binaries run correctly in the build tree:

```
$ .../bld/runtime_output_directory/mysqlbinlog --version
mysqlbinlog Ver 9.6.1 for Linux on x86_64 (Source distribution)
```

`LD_DEBUG=libs` shows a version lookup error against the binary itself, i.e. its own version-requirements section is damaged. The equivalent `.deb` is unaffected, so it is specific to the RPM pipeline.

Consequences: `util.dumpBinlogs()`/`util.loadBinlogs()` fail, and login-path credential storage is unusable because the helper cannot execute `mysql_config_editor`.

This is the same failure already worked around for libfido2 in `src/CMakeLists.txt`:

```cmake
# Do not add an RPATH to libfido2 itself; debugedit corrupts this
LIST(APPEND AUTH_CLIENT_PLUGINS_DEPS_OPTIONS WRITE_RPATH FALSE)
```

**Fix:** apply `WRITE_RPATH FALSE` to the other two bundled binaries.

Note this addresses the symptom. I was not able to identify what actually corrupts the binaries — suppressing debuginfo generation entirely (`debug_package` and `__debug_install_post` both `%{nil}`) does not help, and applying the same RPATH by hand with `patchelf`, with or without `strip -g`, produces a working binary. Since these two binaries do not need an RPATH at all, not writing one is a reasonable fix regardless.

Verified on Oracle Linux 9: with this change the installed package runs `mysqlsh`, `mysqlbinlog` and `mysql_config_editor` correctly with zero unresolved shared libraries.