### PR TITLE
Declare bison and python3 as Debian build dependencies

### DIFF
--- a/packaging/debian/CMakeLists.txt
+++ b/packaging/debian/CMakeLists.txt
@@ -134,6 +134,11 @@ message(STATUS "OS code name    : ${CODENAME}")
 set(EXTRA_CMAKE_OPTS)
 set(DEB_BUILD_DEPS)
 set(DEB_DEPS)
+
+# Always required: mysqlshdk/libs/yparser generates its parsers with bison and
+# drives the generation from a python3 interpreter
+list(APPEND DEB_BUILD_DEPS "bison")
+list(APPEND DEB_BUILD_DEPS "python3")
 if(BUNDLED_SSH_DIR)
   list(APPEND EXTRA_CMAKE_OPTS "-DBUNDLED_SSH_DIR=${BUNDLED_SSH_DIR}")
 else()


### PR DESCRIPTION
`mysqlshdk/libs/yparser` generates its SQL parsers with bison, and `yparser/mysql/CMakeLists.txt` does:

```cmake
find_package(Python3 REQUIRED COMPONENTS Interpreter)
```

Neither `bison` nor `python3` appears in the `Build-Depends` produced by `packaging/debian/CMakeLists.txt`:

```
debhelper (>= 8.9.4), cmake, libssh-dev (>=0.9.2), openssl,
libcurl4-openssl-dev | libcurl-dev, python3-dev (>= 3.8),
libantlr4-runtime-dev (>=4.10), libantlr4-runtime-dev (<<4.11)
```

so the build fails on a clean builder that has only the declared packages installed. `python3-dev` is listed but does not guarantee the interpreter is present in a minimal chroot.

Found while building `.deb` packages on Ubuntu 24.04.