### PR TITLE
Make bundled binary copy targets unique and name-safe

### DIFF
--- a/cmake/exeutils.cmake
+++ b/cmake/exeutils.cmake
@@ -196,7 +196,15 @@ function(install_bundled_binaries)
   foreach(SOURCE_BINARY ${ARG_BINARIES})
     get_filename_component(SOURCE_BINARY_NAME "${SOURCE_BINARY}" NAME)
     set(COPIED_BINARY "${DESTINATION_BINARY_DIR}/${SOURCE_BINARY_NAME}")
-    set(COPY_TARGET "copy_${SOURCE_BINARY_NAME}")
+    # Target names may not contain characters such as dots, and two bundled
+    # files may share a basename, so sanitise and de-duplicate
+    string(REGEX REPLACE "[^a-zA-Z0-9_]" "_" SAFE_BINARY_NAME "${SOURCE_BINARY_NAME}")
+    set(COPY_TARGET "copy_${SAFE_BINARY_NAME}")
+    set(_copy_target_suffix 0)
+    while(TARGET "${COPY_TARGET}")
+      math(EXPR _copy_target_suffix "${_copy_target_suffix} + 1")
+      set(COPY_TARGET "copy_${SAFE_BINARY_NAME}_${_copy_target_suffix}")
+    endwhile()
     SET(COPY_COMMAND "")
 
     if(NOT IS_SYMLINK "${SOURCE_BINARY}")


### PR DESCRIPTION
`install_bundled_binaries()` derives its custom target name directly from the binary basename:

```cmake
set(COPY_TARGET "copy_${SOURCE_BINARY_NAME}")
```

Two problems follow:

- CMake target names may not contain characters such as dots, so bundling a versioned library like `libssl.so.3` produces an invalid target name
- bundling two files that share a basename produces a duplicate target and configure fails

**Fix:** sanitise the basename and append a numeric suffix when the target already exists.

Whether this triggers depends on how much a packager bundles, which is probably why it has not been hit upstream. Downstream packaging that bundles OpenSSL, Python and similar has carried local patches for both variants for several releases.