### PR TITLE
Derive Debian package metadata from the version

### DIFF
--- a/packaging/debian/changelog.in
+++ b/packaging/debian/changelog.in
@@ -1,6 +1,6 @@
 mysql-shell@PRODUCT_SUFFIX@ (@VERSION@@ID_RELEASE@) @CODENAME@; urgency=low
 
   * New Release. For release notes, please refer to
-    https://dev.mysql.com/doc/relnotes/mysql-shell/9.0/en/news-@MYSH_NO_DASH_VERSION@.html
+    https://dev.mysql.com/doc/relnotes/mysql-shell/@MYSH_BASE_VERSION@/en/news-@MYSH_NO_DASH_VERSION@.html
 
  -- MySQL Release Engineering <mysql-build@oss.oracle.com>  @DEB_CHANGELOG_TIMESTAMP@

--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -3,7 +3,7 @@ Section: database
 Priority: optional
 Maintainer: Oracle MySQL Product Engineering Team <mysql-build@oss.oracle.com>
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 8.9.4), cmake, @DEB_BUILD_DEPS@
+Build-Depends: debhelper (>= 11), cmake, @DEB_BUILD_DEPS@
 Homepage: http://dev.mysql.com/downloads/shell
 Vcs-Git: https://github.com/mysql/mysql-shell.git
 Vcs-Browser: https://github.com/mysql/mysql-shell
@@ -15,5 +15,5 @@ Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}, @DEB_DEPS@
 Conflicts: mysql-shell@CONFLICTING_PRODUCT_SUFFIX@
 Replaces: mysql-shell@CONFLICTING_PRODUCT_SUFFIX@
-Description: MySQL Shell (part of MySQL Server) 8.0
+Description: @PRODUCT@
  MySQL query and administration shell client and framework.


### PR DESCRIPTION
Three small inconsistencies in `packaging/debian`:

- `control.in` hardcodes the package Description as `MySQL Shell (part of MySQL Server) 8.0`, which has been wrong since 8.0. The generator already computes a `PRODUCT` variable holding exactly that string (and `copyright.in` already uses `@PRODUCT@`), so use it.
- `changelog.in` hardcodes a `9.0` release-notes URL. Use `@MYSH_BASE_VERSION@`.
- `Build-Depends` asks for `debhelper (>= 8.9.4)` while `debian/compat` is `11`, which requires debhelper 11.

No functional change beyond the debhelper floor.