### PR TITLE
Ignore packaging files generated into the source root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ __pycache__/
 .codex/
 .agents/
 .release-prep/
+
+# written into the source root by the packaging generators
+# (cmake -S packaging/rpm / -S packaging/debian)
+/mysql-shell.spec
+/debian/


### PR DESCRIPTION
`cmake -S packaging/rpm` writes `mysql-shell.spec` and `cmake -S packaging/debian` writes `debian/` into the top of the source tree. Neither is ignored, so generating either leaves the checkout dirty and the files can be committed by accident.