### PR TITLE
Add 8.4 and 9.x reserved keywords to the upgrade check

### DIFF
--- a/modules/util/upgrade_checker/upgrade_check_creators.cc
+++ b/modules/util/upgrade_checker/upgrade_check_creators.cc
@@ -65,9 +65,11 @@ std::unique_ptr<Sql_upgrade_check> get_old_temporal_check() {
 std::unique_ptr<Sql_upgrade_check> get_reserved_keywords_check(
     const Upgrade_info &info) {
   std::string keywords;
-  const auto add_keywords = [&keywords, &info](const char *v, const char *kws) {
+  const auto add_keywords = [&keywords, &info](const char *v, const char *kws,
+                                              const char *max_v = nullptr) {
     Version kv(v);
-    if (info.server_version < kv && info.target_version >= kv) {
+    if (info.server_version < kv && info.target_version >= kv &&
+        (max_v == nullptr || info.target_version < Version(max_v))) {
       if (!keywords.empty()) keywords += ", ";
       keywords += kws;
     }
@@ -83,6 +85,10 @@ std::unique_ptr<Sql_upgrade_check> get_reserved_keywords_check(
 
   add_keywords("8.0.17", "'ARRAY' ,'MEMBER'");
   add_keywords("8.0.31", "'FULL', 'INTERSECT'");
+  add_keywords("8.4.0", "'QUALIFY', 'TABLESAMPLE'");
+  add_keywords("8.4.0", "'MANUAL', 'PARALLEL'", "8.4.11");
+  add_keywords("9.2.0", "'LIBRARY'");
+  add_keywords("9.4.0", "'EXTERNAL'");
 
   keywords = "(" + keywords + ");";
   return std::make_unique<Sql_upgrade_check>(

--- a/modules/util/upgrade_checker/upgrade_check_registry.cc
+++ b/modules/util/upgrade_checker/upgrade_check_registry.cc
@@ -80,7 +80,8 @@ namespace {
 [[maybe_unused]] bool register_reserved =
     Upgrade_check_registry::register_check(&get_reserved_keywords_check,
                                            Target::OBJECT_DEFINITIONS, "8.0.11",
-                                           "8.0.14", "8.0.17", "8.0.31");
+                                           "8.0.14", "8.0.17", "8.0.31", "8.4.0",
+                                           "9.2.0", "9.4.0");
 
 [[maybe_unused]] bool register_utf8mb3 = Upgrade_check_registry::register_check(
     std::bind(&get_utf8mb3_check), Target::OBJECT_DEFINITIONS, "8.0.11");

--- a/unittest/modules/util/upgrade_checker/upgrade_check_creators_t.cc
+++ b/unittest/modules/util/upgrade_checker/upgrade_check_creators_t.cc
@@ -215,5 +215,66 @@ TEST(Upgrade_check_creators,
   }
 }
 
+TEST(Upgrade_check_creators, get_reserved_keywords_check_test) {
+  // Every per-object-type query produced by the reserved keywords check embeds
+  // the same keyword IN-list, so inspecting the first query is enough to verify
+  // which keywords are included for a given source -> target version pair.
+  const auto keyword_list = [](const Version &server, const Version &target) {
+    const auto info = upgrade_info(server, target);
+    const auto check = get_reserved_keywords_check(info);
+    return check->get_queries().front().first;
+  };
+  const auto has = [](const std::string &query, const char *keyword) {
+    return query.find(keyword) != std::string::npos;
+  };
+
+  // 8.0 -> 8.4.8: QUALIFY/TABLESAMPLE plus MANUAL/PARALLEL, which are still
+  // reserved below 8.4.11. LIBRARY/EXTERNAL do not apply yet (target < 9.x).
+  {
+    const auto query = keyword_list(Version(8, 0, 0), Version(8, 4, 8));
+    EXPECT_TRUE(has(query, "'QUALIFY'"));
+    EXPECT_TRUE(has(query, "'TABLESAMPLE'"));
+    EXPECT_TRUE(has(query, "'MANUAL'"));
+    EXPECT_TRUE(has(query, "'PARALLEL'"));
+    EXPECT_FALSE(has(query, "'LIBRARY'"));
+    EXPECT_FALSE(has(query, "'EXTERNAL'"));
+  }
+
+  // 8.0 -> 8.4.11: MANUAL/PARALLEL became nonreserved in 8.4.11 and must drop
+  // out (upper bound of the ranged add_keywords call); QUALIFY/TABLESAMPLE stay.
+  {
+    const auto query = keyword_list(Version(8, 0, 0), Version(8, 4, 11));
+    EXPECT_TRUE(has(query, "'QUALIFY'"));
+    EXPECT_TRUE(has(query, "'TABLESAMPLE'"));
+    EXPECT_FALSE(has(query, "'MANUAL'"));
+    EXPECT_FALSE(has(query, "'PARALLEL'"));
+  }
+
+  // 8.4.0 -> 9.2.0: LIBRARY (reserved since 9.2.0) applies; EXTERNAL (9.4.0)
+  // does not. The 8.4.0 words are not re-reported since the source is 8.4.0.
+  {
+    const auto query = keyword_list(Version(8, 4, 0), Version(9, 2, 0));
+    EXPECT_TRUE(has(query, "'LIBRARY'"));
+    EXPECT_FALSE(has(query, "'EXTERNAL'"));
+    EXPECT_FALSE(has(query, "'QUALIFY'"));
+    EXPECT_FALSE(has(query, "'MANUAL'"));
+  }
+
+  // 8.4.0 -> 9.4.0: both LIBRARY (9.2.0) and EXTERNAL (9.4.0) apply.
+  {
+    const auto query = keyword_list(Version(8, 4, 0), Version(9, 4, 0));
+    EXPECT_TRUE(has(query, "'LIBRARY'"));
+    EXPECT_TRUE(has(query, "'EXTERNAL'"));
+  }
+
+  // 9.2.0 -> 9.4.0: LIBRARY is already reserved on the source, so only EXTERNAL
+  // is newly reserved on the target.
+  {
+    const auto query = keyword_list(Version(9, 2, 0), Version(9, 4, 0));
+    EXPECT_TRUE(has(query, "'EXTERNAL'"));
+    EXPECT_FALSE(has(query, "'LIBRARY'"));
+  }
+}
+
 }  // namespace upgrade_checker
 }  // namespace mysqlsh

--- a/unittest/modules/util/upgrade_checker/upgrade_check_registry_t.cc
+++ b/unittest/modules/util/upgrade_checker/upgrade_check_registry_t.cc
@@ -380,14 +380,20 @@ TEST(Upgrade_check_registry, create_checklist) {
                           {{v5_7_0, Version(8, 0, 11)},
                            {Version(8, 0, 11), Version(8, 0, 14)},
                            {Version(8, 0, 14), Version(8, 0, 17)},
-                           {Version(8, 0, 17), Version(8, 0, 31)}});
+                           {Version(8, 0, 17), Version(8, 0, 31)},
+                           {Version(8, 0, 31), Version(8, 4, 0)},
+                           {Version(8, 4, 0), Version(9, 2, 0)},
+                           {Version(9, 2, 0), Version(9, 4, 0)},
+                           {Version(8, 0, 31), vShell}});
 
   test_check_availability(ids::k_reserved_keywords_check, false,
                           {{v5_7_0, Version(8, 0, 10)},
                            {Version(8, 0, 11), Version(8, 0, 13)},
                            {Version(8, 0, 14), Version(8, 0, 16)},
                            {Version(8, 0, 17), Version(8, 0, 30)},
-                           {Version(8, 0, 31), vShell}});
+                           {Version(8, 4, 0), Version(8, 4, 11)},
+                           {Version(8, 4, 1), Version(9, 1, 0)},
+                           {Version(9, 4, 0), vShell}});
 
   // syntax_check:
   // available: always between series versions


### PR DESCRIPTION
## Description

The upgrade checker's reserved-keywords check reports database objects whose names collide with words that become reserved in the target server version (get_reserved_keywords_check in modules/util/upgrade_checker/upgrade_check_creators.cc). It builds an IN (...) list of keywords via an add_keywords(version, words) helper that includes a set of words only when the upgrade crosses that version, and the check is registered against the same crossing versions (register_reserved in modules/util/upgrade_checker/upgrade_check_registry.cc).

Both the keyword list and the registration stopped at 8.0.31. This caused two problems for upgrades to 8.4 and the 9.x series:

1. Missing keywords. Words that became reserved after 8.0.31 — QUALIFY, TABLESAMPLE (8.4.0), LIBRARY (9.2.0) and EXTERNAL (9.4.0) — were never added, so objects named after them were not reported.
2. Check never ran. Because the check was registered only for the 8.0.11–8.0.31 crossings, it was not even scheduled when the source server was already past 8.0.31. The common 8.0 → 8.4 upgrade skipped the check entirely.

As a result, the objects upgrade fine, but referencing their names unquoted afterward fails on the target (the word is now reserved), and util.checkForServerUpgrade() flagged nothing - so there was no prompt to add backticks or rename before upgrading.

### Fix

Add the words reserved since 8.0.31 and register the check for their crossings:

- MANUAL, PARALLEL — reserved in 8.4.0 but became nonreserved again in 8.4.11
- QUALIFY, TABLESAMPLE — reserved in 8.4.0
- LIBRARY — reserved in 9.2.0
- EXTERNAL — reserved in 9.4.0

To express the MANUAL/PARALLEL window, add_keywords gains an optional upper-bound version; those words are contributed only for targets below 8.4.11. register_reserved is extended with 8.4.0, 9.2.0 and 9.4.0 so the check is scheduled for those upgrade paths (including 8.0 → 8.4, which previously skipped it). Words that were already reserved on the source server are not re-reported.

```
USE sbtest;

CREATE TABLE MANUAL(id INT);
CREATE TABLE PARALLEL(id INT);
CREATE TABLE QUALIFY(id INT);
CREATE TABLE TABLESAMPLE(id INT);

mysql> show tables;
+------------------+
| Tables_in_sbtest |
+------------------+
| MANUAL           |
| PARALLEL         |
| QUALIFY          |
| TABLESAMPLE      |
+------------------+
4 rows in set (0.00 sec)
```

```
{
    "serverAddress": "localhost:33071",
    "serverVersion": "8.0.45 - MySQL Community Server - GPL",
    "targetVersion": "8.4.8",
    "errorCount": 0,
    "warningCount": 4,
    "noticeCount": 0,
    "summary": "No fatal errors were found that would prevent an upgrade, but some potential issues were detected. Please ensure that the reported issues are not significant before upgrading.",
    "checksPerformed": [
        {
            "id": "reservedKeywords",
            "title": "Usage of db objects with names conflicting with new reserved keywords",
            "status": "OK",
            "description": "Warning: The following objects have names that conflict with new reserved keywords. Ensure queries sent by your applications use `quotes` when referring to them or they will result in errors.",
            "documentationLink": "https://dev.mysql.com/doc/refman/en/keywords.html",
            "detectedProblems": [
                {
                    "level": "Warning",
                    "dbObject": "sbtest.MANUAL",
                    "description": "Table name",
                    "dbObjectType": "Table"
                },
                {
                    "level": "Warning",
                    "dbObject": "sbtest.PARALLEL",
                    "description": "Table name",
                    "dbObjectType": "Table"
                },
                {
                    "level": "Warning",
                    "dbObject": "sbtest.QUALIFY",
                    "description": "Table name",
                    "dbObjectType": "Table"
                },
                {
                    "level": "Warning",
                    "dbObject": "sbtest.TABLESAMPLE",
                    "description": "Table name",
                    "dbObjectType": "Table"
                }
            ],
            "solutions": []
        }
    ],
    "manualChecks": []
}
```

```

{
    "serverAddress": "localhost:33071",
    "serverVersion": "8.0.45 - MySQL Community Server - GPL",
    "targetVersion": "8.4.11",
    "errorCount": 0,
    "warningCount": 2,
    "noticeCount": 0,
    "summary": "No fatal errors were found that would prevent an upgrade, but some potential issues were detected. Please ensure that the reported issues are not significant before upgrading.",
    "checksPerformed": [
        {
            "id": "reservedKeywords",
            "title": "Usage of db objects with names conflicting with new reserved keywords",
            "status": "OK",
            "description": "Warning: The following objects have names that conflict with new reserved keywords. Ensure queries sent by your applications use `quotes` when referring to them or they will result in errors.",
            "documentationLink": "https://dev.mysql.com/doc/refman/en/keywords.html",
            "detectedProblems": [
                {
                    "level": "Warning",
                    "dbObject": "sbtest.QUALIFY",
                    "description": "Table name",
                    "dbObjectType": "Table"
                },
                {
                    "level": "Warning",
                    "dbObject": "sbtest.TABLESAMPLE",
                    "description": "Table name",
                    "dbObjectType": "Table"
                }
            ],
            "solutions": []
        }
    ],
    "manualChecks": []
}
```

## Release Notes

Fixed an upgrade-checker issue where objects (schemas, tables, columns, routines, views, triggers, events) whose names match keywords that became reserved in MySQL 8.4 or 9.x — QUALIFY, TABLESAMPLE, LIBRARY, EXTERNAL — were not reported during util.checkForServerUpgrade(). For upgrades from a source newer than 8.0.31 (for example 8.0 to 8.4), the reserved-keywords check was not run at all; it now runs and reports such names so they can be quoted before the upgrade.

### Testing

New/updated cases:

* `unittest/modules/util/upgrade_checker/upgrade_check_creators_t.cc` - asserts the generated keyword list per source/target pair: 8.0→8.4.8 includes QUALIFY/TABLESAMPLE/MANUAL/PARALLEL; 8.0→8.4.11 drops MANUAL/PARALLEL (the un-reserved boundary) while keeping QUALIFY/TABLESAMPLE; 8.4.0→9.2.0 adds only LIBRARY; 8.4.0→9.4.0 adds LIBRARY and EXTERNAL; 9.2.0→9.4.0 adds only EXTERNAL (source already reserves LIBRARY).
* **`unittest/modules/util/upgrade_checker/upgrade_check_registry_t.cc`**  - extended to assert the check is available for the 8.4.0, 9.2.0 and 9.4.0 crossings and unavailable for ranges that cross none (e.g. 8.4.0→8.4.11), correcting the prior assertion that treated 8.0.31→ as unavailable.

## Copyright

This contribution is under the OCA signed by Amazon and covering submissions to the MySQL project.